### PR TITLE
Add multi-server support for Plesk module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Perfex-Plesk
-Modulo per collegare pannelli Plesk a Perfex
+Modulo per collegare pannelli Plesk a Perfex.
+Ora è possibile configurare più server Plesk dalle impostazioni del modulo e scegliere quello predefinito.

--- a/controllers/Plesk_integration.php
+++ b/controllers/Plesk_integration.php
@@ -87,13 +87,29 @@ class Plesk_integration extends AdminController
         }
 
         if ($this->input->post()) {
-            $settings = $this->input->post();
-            
-            // Salva le impostazioni
+            $settings = $this->input->post(null, true);
+
+            // Nuovo server
+            if (!empty($settings['new_server_name']) && !empty($settings['new_server_url'])) {
+                $server_data = [
+                    'name'       => $settings['new_server_name'],
+                    'url'        => $settings['new_server_url'],
+                    'username'   => $settings['new_server_username'],
+                    'password'   => $settings['new_server_password'],
+                    'ssl_verify' => isset($settings['new_server_ssl']) ? 1 : 0,
+                ];
+                $this->plesk_integration_model->add_server($server_data);
+            }
+
+            // Opzioni generiche
             foreach ($settings as $key => $value) {
                 if (strpos($key, 'plesk_') === 0) {
                     update_option($key, $value);
                 }
+            }
+
+            if (isset($settings['plesk_default_server_id'])) {
+                update_option('plesk_default_server_id', (int)$settings['plesk_default_server_id']);
             }
 
             // Test connessione
@@ -112,6 +128,7 @@ class Plesk_integration extends AdminController
         }
 
         $data['title'] = 'Impostazioni Plesk';
+        $data['servers'] = $this->plesk_integration_model->get_servers();
         $this->load->view('admin/plesk_integration/settings', $data);
     }
 }

--- a/install.php
+++ b/install.php
@@ -42,6 +42,20 @@ if (!$CI->db->table_exists(db_prefix() . 'plesk_api_logs')) {
     ) ENGINE=InnoDB DEFAULT CHARSET=' . $CI->db->char_set . ';');
 }
 
+// Tabella per i server Plesk configurati
+if (!$CI->db->table_exists(db_prefix() . 'plesk_servers')) {
+    $CI->db->query('CREATE TABLE `' . db_prefix() . 'plesk_servers` (
+        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `name` varchar(100) NOT NULL,
+        `url` varchar(255) NOT NULL,
+        `username` varchar(100) NOT NULL,
+        `password` varchar(255) NOT NULL,
+        `ssl_verify` tinyint(1) DEFAULT 1,
+        `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (`id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=' . $CI->db->char_set . ';');
+}
+
 // Inserimento opzioni di default
 $default_options = [
     'plesk_api_url' => '',
@@ -51,6 +65,7 @@ $default_options = [
     'plesk_cache_duration' => '30',
     'plesk_auto_sync' => '0',
     'plesk_debug_mode' => '0',
+    'plesk_default_server_id' => '1',
     'plesk_module_version' => PLESK_INTEGRATION_VERSION
 ];
 

--- a/libraries/Plesk_api.php
+++ b/libraries/Plesk_api.php
@@ -9,13 +9,37 @@ class Plesk_api
     private $plesk_password;
     private $ssl_verify;
 
-    public function __construct()
+    public function __construct($params = [])
     {
         $this->CI = &get_instance();
-        $this->plesk_url = get_option('plesk_api_url');
-        $this->plesk_username = get_option('plesk_api_username');
-        $this->plesk_password = get_option('plesk_api_password');
-        $this->ssl_verify = get_option('plesk_ssl_verify') === '1';
+        $this->CI->load->model('plesk_integration_model');
+
+        $server_id = isset($params['server_id']) ? (int)$params['server_id'] : (int)get_option('plesk_default_server_id');
+        $server    = $this->CI->plesk_integration_model->get_server($server_id);
+
+        if ($server) {
+            $this->plesk_url      = $server['url'];
+            $this->plesk_username = $server['username'];
+            $this->plesk_password = $server['password'];
+            $this->ssl_verify     = (bool)$server['ssl_verify'];
+        } else {
+            // retro compatibilità con opzioni precedenti
+            $this->plesk_url      = get_option('plesk_api_url');
+            $this->plesk_username = get_option('plesk_api_username');
+            $this->plesk_password = get_option('plesk_api_password');
+            $this->ssl_verify     = get_option('plesk_ssl_verify') === '1';
+        }
+    }
+
+    public function set_server($server_id)
+    {
+        $server = $this->CI->plesk_integration_model->get_server($server_id);
+        if ($server) {
+            $this->plesk_url      = $server['url'];
+            $this->plesk_username = $server['username'];
+            $this->plesk_password = $server['password'];
+            $this->ssl_verify     = (bool)$server['ssl_verify'];
+        }
     }
 
     /**

--- a/models/Plesk_integration_model.php
+++ b/models/Plesk_integration_model.php
@@ -9,6 +9,40 @@ class Plesk_integration_model extends App_Model
     }
 
     /**
+     * Restituisce l'elenco dei server Plesk configurati
+     */
+    public function get_servers()
+    {
+        return $this->db->order_by('id', 'ASC')->get(db_prefix() . 'plesk_servers')->result_array();
+    }
+
+    /**
+     * Restituisce i dettagli di un singolo server
+     */
+    public function get_server($id)
+    {
+        return $this->db->where('id', $id)->get(db_prefix() . 'plesk_servers')->row_array();
+    }
+
+    /**
+     * Aggiunge un nuovo server Plesk
+     */
+    public function add_server($data)
+    {
+        $this->db->insert(db_prefix() . 'plesk_servers', $data);
+        return $this->db->insert_id();
+    }
+
+    /**
+     * Elimina server
+     */
+    public function delete_server($id)
+    {
+        $this->db->where('id', $id)->delete(db_prefix() . 'plesk_servers');
+        return $this->db->affected_rows() > 0;
+    }
+
+    /**
      * Ottiene siti web dalla cache
      */
     public function get_cached_websites()
@@ -69,6 +103,7 @@ class Plesk_integration_model extends App_Model
     {
         $this->db->query("DROP TABLE IF EXISTS `" . db_prefix() . "plesk_websites_cache`");
         $this->db->query("DROP TABLE IF EXISTS `" . db_prefix() . "plesk_api_logs`");
+        $this->db->query("DROP TABLE IF EXISTS `" . db_prefix() . "plesk_servers`");
         
         // Rimuove le opzioni
         $this->db->where('name LIKE', 'plesk_%')

--- a/views/admin/plesk_integration/settings.php
+++ b/views/admin/plesk_integration/settings.php
@@ -11,96 +11,99 @@
 
                         <?php echo form_open(admin_url('plesk_integration/settings')); ?>
                         
-                        <div class="row">
-                            <div class="col-md-6">
-                                <h5><strong>Configurazione API Plesk</strong></h5>
-                                
-                                <div class="form-group">
-                                    <label for="plesk_api_url">URL Server Plesk</label>
-                                    <input type="url" id="plesk_api_url" name="plesk_api_url" 
-                                           class="form-control" 
-                                           value="<?php echo get_option('plesk_api_url'); ?>"
-                                           placeholder="https://il-tuo-server.plesk.com:8443"
-                                           required>
-                                    <small class="text-muted">
-                                        Inserisci l'URL completo del tuo server Plesk (inclusi https:// e porta)
-                                    </small>
-                                </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <h5><strong>Opzioni Cache</strong></h5>
 
-                                <div class="form-group">
-                                    <label for="plesk_api_username">Username API</label>
-                                    <input type="text" id="plesk_api_username" name="plesk_api_username" 
-                                           class="form-control" 
-                                           value="<?php echo get_option('plesk_api_username'); ?>"
-                                           placeholder="admin o username API"
-                                           required>
-                                </div>
-
-                                <div class="form-group">
-                                    <label for="plesk_api_password">Password API</label>
-                                    <input type="password" id="plesk_api_password" name="plesk_api_password" 
-                                           class="form-control" 
-                                           value="<?php echo get_option('plesk_api_password'); ?>"
-                                           placeholder="Password o API Key"
-                                           required>
-                                    <small class="text-muted">
-                                        Puoi usare la password admin o creare una API Key dedicata
-                                    </small>
-                                </div>
-
-                                <div class="form-group">
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" name="plesk_ssl_verify" value="1" 
-                                                   <?php echo get_option('plesk_ssl_verify') ? 'checked' : ''; ?>>
-                                            Verifica certificato SSL
-                                        </label>
+                                    <div class="form-group">
+                                        <label for="plesk_cache_duration">Durata Cache (minuti)</label>
+                                        <input type="number" id="plesk_cache_duration" name="plesk_cache_duration"
+                                               class="form-control"
+                                               value="<?php echo get_option('plesk_cache_duration', 30); ?>"
+                                               min="5" max="1440">
                                         <small class="text-muted">
-                                            Disabilita solo per server di test con certificati self-signed
+                                            Per quanto tempo mantenere in cache i dati da Plesk
                                         </small>
                                     </div>
-                                </div>
-                            </div>
 
-                            <div class="col-md-6">
-                                <h5><strong>Opzioni Cache</strong></h5>
-                                
-                                <div class="form-group">
-                                    <label for="plesk_cache_duration">Durata Cache (minuti)</label>
-                                    <input type="number" id="plesk_cache_duration" name="plesk_cache_duration" 
-                                           class="form-control" 
-                                           value="<?php echo get_option('plesk_cache_duration', 30); ?>"
-                                           min="5" max="1440">
-                                    <small class="text-muted">
-                                        Per quanto tempo mantenere in cache i dati da Plesk
-                                    </small>
-                                </div>
+                                    <div class="form-group">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="plesk_auto_sync" value="1"
+                                                       <?php echo get_option('plesk_auto_sync') ? 'checked' : ''; ?>>
+                                                Sincronizzazione automatica
+                                            </label>
+                                            <small class="text-muted">
+                                                Aggiorna automaticamente i dati ogni ora
+                                            </small>
+                                        </div>
+                                    </div>
 
-                                <div class="form-group">
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" name="plesk_auto_sync" value="1" 
-                                                   <?php echo get_option('plesk_auto_sync') ? 'checked' : ''; ?>>
-                                            Sincronizzazione automatica
-                                        </label>
-                                        <small class="text-muted">
-                                            Aggiorna automaticamente i dati ogni ora
-                                        </small>
+                                    <h5><strong>Log e Debug</strong></h5>
+
+                                    <div class="form-group">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="plesk_debug_mode" value="1"
+                                                       <?php echo get_option('plesk_debug_mode') ? 'checked' : ''; ?>>
+                                                Modalità Debug
+                                            </label>
+                                            <small class="text-muted">
+                                                Abilita per registrare richieste API nei log
+                                            </small>
+                                        </div>
                                     </div>
                                 </div>
 
-                                <h5><strong>Log e Debug</strong></h5>
-                                
-                                <div class="form-group">
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" name="plesk_debug_mode" value="1" 
-                                                   <?php echo get_option('plesk_debug_mode') ? 'checked' : ''; ?>>
-                                            Modalità Debug
-                                        </label>
-                                        <small class="text-muted">
-                                            Abilita per registrare richieste API nei log
-                                        </small>
+                                <div class="col-md-6">
+                                    <h5><strong>Server configurati</strong></h5>
+                                    <table class="table">
+                                        <thead>
+                                            <tr>
+                                                <th>Predefinito</th>
+                                                <th>Nome</th>
+                                                <th>URL</th>
+                                                <th>Username</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <?php foreach($servers as $server){ ?>
+                                                <tr>
+                                                    <td>
+                                                        <input type="radio" name="plesk_default_server_id" value="<?php echo $server['id']; ?>" <?php echo get_option('plesk_default_server_id') == $server['id'] ? 'checked' : ''; ?>>
+                                                    </td>
+                                                    <td><?php echo html_escape($server['name']); ?></td>
+                                                    <td><?php echo html_escape($server['url']); ?></td>
+                                                    <td><?php echo html_escape($server['username']); ?></td>
+                                                </tr>
+                                            <?php } ?>
+                                        </tbody>
+                                    </table>
+
+                                    <h5><strong>Aggiungi nuovo server</strong></h5>
+                                    <div class="form-group">
+                                        <label for="new_server_name">Nome</label>
+                                        <input type="text" name="new_server_name" id="new_server_name" class="form-control">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="new_server_url">URL</label>
+                                        <input type="url" name="new_server_url" id="new_server_url" class="form-control" placeholder="https://server:8443">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="new_server_username">Username</label>
+                                        <input type="text" name="new_server_username" id="new_server_username" class="form-control">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="new_server_password">Password/API Key</label>
+                                        <input type="password" name="new_server_password" id="new_server_password" class="form-control">
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="new_server_ssl" value="1" checked>
+                                                Verifica certificato SSL
+                                            </label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- create `plesk_servers` table and add default option
- expose CRUD helpers in the model
- allow adding new servers and selecting default from settings page
- load selected server data in API library
- update README

## Testing
- `true` *(no tests provided)*